### PR TITLE
Generify the addition of modifiers to a Html / Svg VNode

### DIFF
--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -88,7 +88,7 @@ sealed trait BasicVNode extends VNode {
   @inline def static(key: Key.Value)(renderFn: => VDomModifier): ConditionalVNode = conditional(key)(false)(renderFn)
 }
 sealed trait TypedVNode[T <: BasicVNode] extends BasicVNode {
-  def modified(updatedModifiers: js.Array[VDomModifier]): T
+  protected def modified(updatedModifiers: js.Array[VDomModifier]): T
 
   def apply(args: VDomModifier*): T = {
     val newModifiers:js.Array[VDomModifier] = args match {
@@ -114,8 +114,8 @@ final case class ConditionalVNode(baseNode: BasicVNode, key: Key.Value, shouldRe
   def prepend(args: VDomModifier*): ConditionalVNode = copy(baseNode = baseNode.prepend(args))
 }
 final case class HtmlVNode(nodeType: String, modifiers: js.Array[VDomModifier]) extends TypedVNode[HtmlVNode] {
-  override def modified(updatedModifiers: js.Array[VDomModifier]): HtmlVNode = copy(modifiers = updatedModifiers)
+  protected def modified(updatedModifiers: js.Array[VDomModifier]): HtmlVNode = copy(modifiers = updatedModifiers)
 }
 final case class SvgVNode(nodeType: String, modifiers: js.Array[VDomModifier]) extends TypedVNode[SvgVNode] {
-  override def modified(updatedModifiers: js.Array[VDomModifier]): SvgVNode = copy(modifiers = updatedModifiers)
+  protected def modified(updatedModifiers: js.Array[VDomModifier]): SvgVNode = copy(modifiers = updatedModifiers)
 }

--- a/src/main/scala/outwatch/dom/helpers/NativeHelpers.scala
+++ b/src/main/scala/outwatch/dom/helpers/NativeHelpers.scala
@@ -3,18 +3,6 @@ package outwatch.dom.helpers
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSBracketAccess
 
-private[outwatch] object JsArrayHelpers {
-  def appendSeq[T](source: js.Array[T], other: Seq[T]): js.Array[T] = other match {
-    case wrappedOther:js.WrappedArray[T] => source.concat(wrappedOther.array)
-    case _                               => source ++ other
-  }
-
-  def prependSeq[T](source: js.Array[T], other: Seq[T]): js.Array[T] = other match {
-    case wrappedOther:js.WrappedArray[T] => wrappedOther.array.concat(source)
-    case _                               => other.++(source)(collection.breakOut)
-  }
-}
-
 @js.native
 private[outwatch] trait DictionaryRawApply[A] extends js.Object {
   @JSBracketAccess
@@ -27,4 +15,14 @@ private[outwatch] object NativeHelpers {
   }
 
   @inline def assign[T](value: T)(f: T => Unit): T = { f(value); value }
+
+  @inline def appendSeq[T](source: js.Array[T], other: Seq[T]): js.Array[T] = other match {
+    case wrappedOther:js.WrappedArray[T] => source.concat(wrappedOther.array)
+    case _                               => source ++ other
+  }
+
+  @inline def prependSeq[T](source: js.Array[T], other: Seq[T]): js.Array[T] = other match {
+    case wrappedOther:js.WrappedArray[T] => wrappedOther.array.concat(source)
+    case _                               => other.++(source)(collection.breakOut)
+  }
 }

--- a/src/main/scala/outwatch/dom/helpers/NativeHelpers.scala
+++ b/src/main/scala/outwatch/dom/helpers/NativeHelpers.scala
@@ -3,11 +3,24 @@ package outwatch.dom.helpers
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSBracketAccess
 
+private[outwatch] object JsArrayHelpers {
+  def appendSeq[T](source: js.Array[T], other: Seq[T]): js.Array[T] = other match {
+    case wrappedOther:js.WrappedArray[T] => source.concat(wrappedOther.array)
+    case _                               => source ++ other
+  }
+
+  def prependSeq[T](source: js.Array[T], other: Seq[T]): js.Array[T] = other match {
+    case wrappedOther:js.WrappedArray[T] => wrappedOther.array.concat(source)
+    case _                               => other.++(source)(collection.breakOut)
+  }
+}
+
 @js.native
 private[outwatch] trait DictionaryRawApply[A] extends js.Object {
   @JSBracketAccess
   def apply(key: String): js.UndefOr[A] = js.native
 }
+
 private[outwatch] object NativeHelpers {
   implicit class WithRaw[A](val dict: js.Dictionary[A]) extends AnyVal {
     @inline def raw: DictionaryRawApply[A] = dict.asInstanceOf[DictionaryRawApply[A]]


### PR DESCRIPTION
This is an attempt to generify the `apply` and `prepend` methods into a common trait since they contain the same code, for both html and svg.  

Since I need to create a third subclass of BasicVNode, I would like to avoid copying the code for those methods for a third time.